### PR TITLE
Fix RIAC bug

### DIFF
--- a/core/encrypt/he/RandomizedIterativeAffine.py
+++ b/core/encrypt/he/RandomizedIterativeAffine.py
@@ -16,6 +16,9 @@ Randomized Iterative Affine Cipher
 The main code is partially grabbed from:
 https://github.com/lyyanjiu1jia1/RandomizedIterativeAffineCipher
 but with some optimizations.
+
+# TODO:
+# add capacity check.
 """
 
 import math
@@ -125,10 +128,11 @@ class IterativeAffineCiphertext(object):
                 raise TypeError("Two addends must have equal multiples and n_finals")
             if self.mult_times > other.mult_times:
                 mult_times_diff = self.mult_times - other.mult_times
-                cipher1 = util.t_mod(util.add(self.cipher1,util.mul(util.mul(
-                    other.cipher1, other.multiple), mult_times_diff)), self.n_final)
-                cipher2 = util.t_mod(util.add(self.cipher2, util.mul(util.mul(
-                    other.cipher2, other.multiple), mult_times_diff)), self.n_final)
+                multiplier = util.powmod(self.multiple, mult_times_diff, self.n_final)
+                cipher1 = util.t_mod(util.add(self.cipher1, util.mul(other.cipher1,
+                    multiplier)), self.n_final)
+                cipher2 = util.t_mod(util.add(self.cipher2, util.mul(other.cipher2,
+                    multiplier)), self.n_final)
                 return IterativeAffineCiphertext(
                     cipher1=cipher1,
                     cipher2=cipher2,
@@ -138,10 +142,11 @@ class IterativeAffineCiphertext(object):
                 )
             elif self.mult_times < other.mult_times:
                 mult_times_diff = other.mult_times - self.mult_times
-                cipher1 = util.t_mod(util.add(util.mul(util.mul(self.cipher1,
-                    self.multiple), mult_times_diff), other.cipher1), self.n_final)
-                cipher2 = util.t_mod(util.add(util.mul(util.mul(self.cipher2,
-                    self.multiple), mult_times_diff), other.cipher2), self.n_final)
+                multiplier = util.powmod(self.multiple, mult_times_diff, self.n_final)
+                cipher1 = util.t_mod(util.add(util.mul(self.cipher1, multiplier),
+                    other.cipher1), self.n_final)
+                cipher2 = util.t_mod(util.add(util.mul(self.cipher2, multiplier),
+                    other.cipher2), self.n_final)
                 return IterativeAffineCiphertext(
                     cipher1=cipher1,
                     cipher2=cipher2,

--- a/tests/encrypt/he/test_RIAC.py
+++ b/tests/encrypt/he/test_RIAC.py
@@ -25,6 +25,9 @@ from core.encrypt.he import RandomizedIterativeAffine as RIAC
 
 import unittest   # The test framework
 
+_ASSERT_DECIMAL = 1e-6
+_RELL_ERROR = 1e-6
+
 class TestRIAC(unittest.TestCase):
     
     def __init__(self, *args, **kwargs):
@@ -68,6 +71,24 @@ class TestRIAC(unittest.TestCase):
         ciphertext = self.encrypt_key.encrypt(plaintext)
         self.assertEqual(self.encrypt_key.decrypt(n * ciphertext), n * plaintext)
 
+    def test_mult_add(self):
+        plaintext1 = 1e4 * (random.random() - 0.5)
+        plaintext2 = 1e4 * (random.random() - 0.5)
+        n1 = random.randint(-1e6, 1e6)
+        n2 = random.randint(-1e6, 1e6)
+        ciphertext1 = self.encrypt_key.encrypt(plaintext1)
+        ciphertext2 = self.encrypt_key.encrypt(plaintext2)
+        decrypted = self.encrypt_key.decrypt(ciphertext1 * n1 * n2 + ciphertext2)
+        result = plaintext1 * n1 * n2 + plaintext2
+        if abs(decrypted - result) > _ASSERT_DECIMAL:
+            if abs(decrypted/result - 1) < _RELL_ERROR:
+                print("WARNING in test_mult_add")
+                print("Abs diff %.8f is larger than %.8f,"%(abs(decrypted - result), _ASSERT_DECIMAL))
+                print("but rel diff %.8f is smaller than %.8f"%(abs(decrypted/result - 1), _RELL_ERROR))
+            else:
+                self.assertAlmostEqual(decrypted, result, _ASSERT_DECIMAL, "Assert almost equal failed!")
+        return None
+
     def test_mean_int(self):
         n = 1000
         plaintexts = numpy.random.randint(-1e6, 1e6, n)
@@ -90,6 +111,8 @@ class TestRIAC(unittest.TestCase):
                                plaintexts_mean,
                                delta=1e-6)
         return None
+
+    
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# For issue fixes
Fixes ISSUE #6 

# For updates and changes
Changes:
1. update the computation issue when multiples are different between "self" encrypted number and "other" encrypted number. The previous computation is coincident with the correct computation when multiples=1, but fails when multiples>1. This fix implements the correct computation flow so that RIAC can get the correct result when multiples>1.
